### PR TITLE
TransferTaskの削除が正常にできない問題のFix

### DIFF
--- a/src/components/FormEdit.vue
+++ b/src/components/FormEdit.vue
@@ -497,7 +497,7 @@
             <b-col>
               <b-form-checkbox
                 id="formColRequired"
-                v-model="formColData.required"
+                v-model="formColData.validations.required"
                 value="true"
                 unchecked-value="false"
               />

--- a/src/components/transfer/MailTransferEdit.vue
+++ b/src/components/transfer/MailTransferEdit.vue
@@ -277,22 +277,10 @@ export default {
     },
     insertTag: function (target) {
       var targetObj = this.$refs[target]
-      console.log(targetObj)
       var cursorPosition = targetObj.selectionStart
       var textBefore = targetObj.value.substr(0, cursorPosition)
       var textAfter = targetObj.value.substr(cursorPosition, targetObj.length)
       this.$set(this.$data.tmpTransferTask.config, target, textBefore + this.$refs.selectedTag.value + textAfter)
-
-      /*
-      var mailBody = this.$refs.mailBody
-      var cursorPosition = mailBody.selectionStart
-      var textBefore = mailBody.value.substr(0, cursorPosition)
-      var textAfter = mailBody.value.substr(cursorPosition, mailBody.length)
-      this.$set(this.$data.tmpTransferTask.config, 'mailBody', textBefore + this.$refs.selectedTag.value + textAfter)
-      */
-      console.log(this)
-      // this.$set(this.$data.tmpTransferTask.config, 'mailBody', textBefore + this.$computed.selectedFormColumnNameTag + textAfter)
-      // alert(mailBody.selectionStart)
     }
   }
 }

--- a/src/components/transfer/Transfers.vue
+++ b/src/components/transfer/Transfers.vue
@@ -212,7 +212,12 @@ export default {
       this.$data.transferTaskDeleteModalState = 0
     },
     transferDelete: function (index) {
-      this.$set(this.$data.transferTask[index], 'del_flg', 1)
+      var tmp = this.$data.transferTask.filter(task => task.del_flg === 0)[index]
+      this.$data.transferTask.forEach((task, index) => {
+        if (task === tmp) {
+          this.$set(this.$data.transferTask[index], 'del_flg', 1)
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
元のTraksferTaskListとfilterdしたリストの間でインデックスずれが発生するため、インデックス比較ではなくオブジェクト等価性チェックで対応